### PR TITLE
Fix Neo4j version to support relationship vector search (>=5.18)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         condition: service_started
 
   neo4j:
-    image: neo4j:5.15-community
+    image: neo4j:5.18-community
     container_name: mirofish-neo4j
     ports:
       - "7474:7474"   # Neo4j Browser


### PR DESCRIPTION
Fix Neo4j version mismatch causing missing vector procedure

The current docker-compose.yml uses neo4j:5.15-community, but the backend calls db.index.vector.queryRelationships, which is only available in Neo4j >= 5.18.

This causes runtime warnings:
Neo.ClientError.Procedure.ProcedureNotFound

Updating Neo4j to 5.18 resolves the issue.

No other changes required.