### PR TITLE
fix: report chat returning nested object instead of string

### DIFF
--- a/backend/app/api/report.py
+++ b/backend/app/api/report.py
@@ -262,7 +262,12 @@ def chat_with_report_agent():
         )
 
         result = agent.chat(message=message, chat_history=chat_history)
-        return jsonify({"success": True, "data": {"response": result, "simulation_id": simulation_id}})
+        return jsonify({"success": True, "data": {
+            "response": result.get("response", ""),
+            "sources": result.get("sources", []),
+            "tool_calls": result.get("tool_calls", []),
+            "simulation_id": simulation_id
+        }})
 
     except Exception as e:
         logger.error(f"Chat failed: {str(e)}")


### PR DESCRIPTION
## Problem

The `/api/report/chat` endpoint was passing the full dict from `agent.chat()` directly as `data.response`. Since `agent.chat()` returns `{"response": "...", "sources": [...], "tool_calls": [...]}`, the frontend ended up receiving an object instead of a string — so chat replies either showed as `[object Object]` or didn't render at all.

## Fix

Flatten the result dict into separate top-level fields in the response payload so `data.response` is a plain string, matching what the frontend expects at `Step5Interaction.vue:700`.