### PR TITLE
fix: prevent simulation destruction on page refresh + add dashboard view

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -57,6 +57,7 @@ def create_app(config_class=Config):
     # Register simulation process cleanup function (ensure all simulation processes terminate on server shutdown)
     from .services.simulation_runner import SimulationRunner
     SimulationRunner.register_cleanup()
+    SimulationRunner.reconnect_orphaned_simulations()
     if should_log_startup:
         logger.info("Simulation process cleanup function registered")
 

--- a/backend/app/api/graph.py
+++ b/backend/app/api/graph.py
@@ -255,6 +255,8 @@ def generate_ontology():
         })
         
     except Exception as e:
+        logger.error(f"Ontology generation failed: {e}")
+        logger.error(traceback.format_exc())
         return jsonify({
             "success": False,
             "error": str(e),

--- a/backend/app/api/simulation.py
+++ b/backend/app/api/simulation.py
@@ -1532,40 +1532,44 @@ def start_simulation():
 
         force_restarted = False
         
-        # Intelligently handle status: if preparation work is complete, reset status to ready
         if state.status != SimulationStatus.READY:
             # Check if preparation is complete
             is_prepared, prepare_info = _check_simulation_prepared(simulation_id)
 
             if is_prepared:
-                # Preparation work complete, verify if simulation is not already running
+                # Check if simulation process is really running
                 if state.status == SimulationStatus.RUNNING:
-                    # Check if simulation process is really running
                     run_state = SimulationRunner.get_run_state(simulation_id)
                     if run_state and run_state.runner_status.value == "running":
-                        # Process is indeed running
                         if force:
-                            # Force mode：Stop runningSimulation
-                            logger.info(f"Force mode：Stop runningSimulation {simulation_id}")
+                            logger.info(f"Force mode: stopping running simulation {simulation_id}")
                             try:
                                 SimulationRunner.stop_simulation(simulation_id)
                             except Exception as e:
                                 logger.warning(f"Warning when stopping simulation: {str(e)}")
                         else:
+                            # Ensure state.json reflects running status
+                            manager._save_simulation_state(state)
                             return jsonify({
                                 "success": False,
                                 "error": f"Simulation is running. Please call /stop first or use force=true to force restart."
                             }), 400
 
-                # If force mode，Clean runtime logs
+                # If force mode, clean runtime logs and Neo4j graph data
                 if force:
                     logger.info(f"Force mode: cleaning simulation runtime files for {simulation_id}")
-                    cleanup_result = SimulationRunner.cleanup_simulation_logs(simulation_id)
+                    cleanup_storage = current_app.extensions.get('neo4j_storage')
+                    cleanup_graph_id = state.graph_id
+                    cleanup_result = SimulationRunner.cleanup_simulation_logs(
+                        simulation_id,
+                        storage=cleanup_storage,
+                        graph_id=cleanup_graph_id
+                    )
                     if not cleanup_result.get("success"):
                         logger.warning(f"Warning when cleaning logs: {cleanup_result.get('errors')}")
                     force_restarted = True
 
-                # Process does not exist or has ended，Reset status to ready
+                # Process does not exist or has ended, reset status to ready
                 logger.info(f"Simulation {simulation_id} preparation complete, resetting status to ready (previous status: {state.status.value})")
                 state.status = SimulationStatus.READY
                 manager._save_simulation_state(state)
@@ -1595,13 +1599,22 @@ def start_simulation():
             
             logger.info(f"Enable knowledge graph memory update: simulation_id={simulation_id}, graph_id={graph_id}")
         
+        # Get GraphStorage for graph memory update
+        storage = None
+        if enable_graph_memory_update:
+            storage = current_app.extensions.get('neo4j_storage')
+            if not storage:
+                logger.warning("GraphStorage not available, graph memory update will be disabled")
+                enable_graph_memory_update = False
+
         # Start simulation
         run_state = SimulationRunner.start_simulation(
             simulation_id=simulation_id,
             platform=platform,
             max_rounds=max_rounds,
             enable_graph_memory_update=enable_graph_memory_update,
-            graph_id=graph_id
+            graph_id=graph_id,
+            storage=storage
         )
         
         # Update simulation status

--- a/backend/app/services/ontology_generator.py
+++ b/backend/app/services/ontology_generator.py
@@ -265,6 +265,9 @@ Based on the above content, design entity types and relationship types suitable 
         if "analysis_summary" not in result:
             result["analysis_summary"] = ""
 
+        # Filter out malformed entity types (missing 'name' key)
+        result["entity_types"] = [e for e in result["entity_types"] if "name" in e]
+
         # Validate entity types
         for entity in result["entity_types"]:
             if "attributes" not in entity:
@@ -274,6 +277,9 @@ Based on the above content, design entity types and relationship types suitable 
             # Ensure description doesn't exceed 100 characters
             if len(entity.get("description", "")) > 100:
                 entity["description"] = entity["description"][:97] + "..."
+
+        # Filter out malformed edge types (missing 'name' key)
+        result["edge_types"] = [e for e in result["edge_types"] if "name" in e]
 
         # Validate relationship types
         for edge in result["edge_types"]:

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -1098,7 +1098,7 @@ class SimulationRunner:
         return result
     
     @classmethod
-    def cleanup_simulation_logs(cls, simulation_id: str) -> Dict[str, Any]:
+    def cleanup_simulation_logs(cls, simulation_id: str, storage=None, graph_id: str = None) -> Dict[str, Any]:
         """
         Clean up simulation run logs (for force restart)
         
@@ -1112,10 +1112,14 @@ class SimulationRunner:
         - reddit_simulation.db (simulation database)
         - env_status.json (environment status)
         
+        If storage and graph_id are provided, also clears Neo4j graph data.
+        
         Note: Does not delete config files (simulation_config.json) and profile files
         
         Args:
             simulation_id: Simulation ID
+            storage: Optional GraphStorage instance for Neo4j cleanup
+            graph_id: Optional graph ID to clear in Neo4j
             
         Returns:
             Cleanup result information
@@ -1169,6 +1173,16 @@ class SimulationRunner:
         # Clean up in-memory run state
         if simulation_id in cls._run_states:
             del cls._run_states[simulation_id]
+        
+        # Clean up Neo4j graph data if storage provided
+        if storage and graph_id:
+            try:
+                storage.delete_graph(graph_id)
+                cleaned_files.append(f"neo4j:graph:{graph_id}")
+                logger.info(f"Cleared Neo4j graph data: graph_id={graph_id}")
+            except Exception as e:
+                errors.append(f"Failed to clear Neo4j graph: {str(e)}")
+                logger.error(f"Failed to clear Neo4j graph data: {e}")
         
         logger.info(f"Cleanup simulation logs completed: {simulation_id}, deleted files: {cleaned_files}")
         

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -270,6 +270,29 @@ class SimulationRunner:
                 
                 cls._run_states[sim_id] = state
                 
+                # Try to reconnect GraphMemoryUpdater
+                graph_id = None
+                state_json = os.path.join(cls.RUN_STATE_DIR, sim_id, "state.json")
+                if os.path.exists(state_json):
+                    try:
+                        with open(state_json, 'r', encoding='utf-8') as f:
+                            sim_state = json.load(f)
+                        graph_id = sim_state.get("graph_id")
+                    except Exception:
+                        pass
+                
+                if graph_id:
+                    try:
+                        from ..storage import Neo4jStorage
+                        from ..config import Config
+                        storage = Neo4jStorage(Config.NEO4J_URI, Config.NEO4J_USER, Config.NEO4J_PASSWORD)
+                        GraphMemoryManager.create_updater(sim_id, graph_id, storage)
+                        cls._graph_memory_enabled[sim_id] = True
+                        logger.info(f"Reconnected graph memory updater: {sim_id}, graph_id={graph_id}")
+                    except Exception as e:
+                        logger.warning(f"Could not reconnect graph memory for {sim_id}: {e}")
+                        cls._graph_memory_enabled[sim_id] = False
+                
                 monitor_thread = threading.Thread(
                     target=cls._monitor_orphaned_simulation,
                     args=(sim_id, pid),
@@ -337,6 +360,12 @@ class SimulationRunner:
             state.error = str(e)
             cls._save_run_state(state)
         finally:
+            if cls._graph_memory_enabled.get(simulation_id, False):
+                try:
+                    GraphMemoryManager.stop_updater(simulation_id)
+                except Exception:
+                    pass
+                cls._graph_memory_enabled.pop(simulation_id, None)
             cls._monitor_threads.pop(simulation_id, None)
     
     @classmethod

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -315,8 +315,9 @@ class SimulationRunner:
         if not state:
             return
         
-        twitter_position = 0
-        reddit_position = 0
+        # Start from end of existing logs to avoid re-processing old actions
+        twitter_position = os.path.getsize(twitter_log) if os.path.exists(twitter_log) else 0
+        reddit_position = os.path.getsize(reddit_log) if os.path.exists(reddit_log) else 0
         
         def is_alive():
             try:

--- a/backend/app/services/simulation_runner.py
+++ b/backend/app/services/simulation_runner.py
@@ -227,6 +227,119 @@ class SimulationRunner:
     _graph_memory_enabled: Dict[str, bool] = {}  # simulation_id -> enabled
     
     @classmethod
+    def reconnect_orphaned_simulations(cls):
+        """
+        On startup, find simulations with runner_status='running' in their
+        run_state.json whose process is still alive, and start a monitor
+        thread so run_state.json keeps updating.
+        """
+        if not os.path.exists(cls.RUN_STATE_DIR):
+            return
+        
+        for sim_id in os.listdir(cls.RUN_STATE_DIR):
+            state_file = os.path.join(cls.RUN_STATE_DIR, sim_id, "run_state.json")
+            if not os.path.exists(state_file):
+                continue
+            
+            try:
+                state = cls._load_run_state(sim_id)
+                if not state or state.runner_status != RunnerStatus.RUNNING:
+                    continue
+                
+                pid = state.process_pid
+                if not pid:
+                    continue
+                
+                # Check if process is still alive
+                try:
+                    os.kill(pid, 0)
+                except (ProcessLookupError, PermissionError):
+                    state.runner_status = RunnerStatus.STOPPED
+                    state.twitter_running = False
+                    state.reddit_running = False
+                    state.completed_at = datetime.now().isoformat()
+                    state.error = "Process died while backend was restarting"
+                    cls._save_run_state(state)
+                    logger.info(f"Marked dead simulation as stopped: {sim_id} (pid {pid})")
+                    continue
+                
+                if sim_id in cls._monitor_threads:
+                    continue
+                
+                logger.info(f"Reconnecting to orphaned simulation: {sim_id} (pid {pid})")
+                
+                cls._run_states[sim_id] = state
+                
+                monitor_thread = threading.Thread(
+                    target=cls._monitor_orphaned_simulation,
+                    args=(sim_id, pid),
+                    daemon=True
+                )
+                monitor_thread.start()
+                cls._monitor_threads[sim_id] = monitor_thread
+                
+            except Exception as e:
+                logger.error(f"Failed to reconnect simulation {sim_id}: {e}")
+    
+    @classmethod
+    def _monitor_orphaned_simulation(cls, simulation_id: str, pid: int):
+        """Monitor an orphaned simulation by reading its action logs and checking PID liveness."""
+        sim_dir = os.path.join(cls.RUN_STATE_DIR, simulation_id)
+        twitter_log = os.path.join(sim_dir, "twitter", "actions.jsonl")
+        reddit_log = os.path.join(sim_dir, "reddit", "actions.jsonl")
+        
+        state = cls.get_run_state(simulation_id)
+        if not state:
+            return
+        
+        twitter_position = 0
+        reddit_position = 0
+        
+        def is_alive():
+            try:
+                os.kill(pid, 0)
+                return True
+            except (ProcessLookupError, PermissionError):
+                return False
+        
+        try:
+            while is_alive():
+                if os.path.exists(twitter_log):
+                    twitter_position = cls._read_action_log(
+                        twitter_log, twitter_position, state, "twitter"
+                    )
+                if os.path.exists(reddit_log):
+                    reddit_position = cls._read_action_log(
+                        reddit_log, reddit_position, state, "reddit"
+                    )
+                cls._save_run_state(state)
+                time.sleep(2)
+            
+            # Process ended — final read
+            if os.path.exists(twitter_log):
+                cls._read_action_log(twitter_log, twitter_position, state, "twitter")
+            if os.path.exists(reddit_log):
+                cls._read_action_log(reddit_log, reddit_position, state, "reddit")
+            
+            if state.twitter_completed and state.reddit_completed:
+                state.runner_status = RunnerStatus.COMPLETED
+            else:
+                state.runner_status = RunnerStatus.STOPPED
+            state.twitter_running = False
+            state.reddit_running = False
+            state.completed_at = datetime.now().isoformat()
+            cls._save_run_state(state)
+            logger.info(f"Orphaned simulation finished: {simulation_id}, status={state.runner_status.value}")
+            
+        except Exception as e:
+            logger.error(f"Orphan monitor error for {simulation_id}: {e}")
+            state.runner_status = RunnerStatus.FAILED
+            state.error = str(e)
+            cls._save_run_state(state)
+        finally:
+            cls._monitor_threads.pop(simulation_id, None)
+    
+    @classmethod
     def get_run_state(cls, simulation_id: str) -> Optional[SimulationRunState]:
         """Get run state"""
         if simulation_id in cls._run_states:

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -38,7 +38,7 @@ class LLMClient:
 
         # Ollama context window size — prevents prompt truncation.
         # Read from env OLLAMA_NUM_CTX, default 8192 (Ollama default is only 2048).
-        self._num_ctx = int(os.environ.get('OLLAMA_NUM_CTX', '8192'))
+        self._num_ctx = int(os.environ.get('OLLAMA_NUM_CTX', '32768'))
 
     def _is_ollama(self) -> bool:
         """Check if we're talking to an Ollama server."""

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 // Create axios instance
 const service = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5001',
+  baseURL: import.meta.env.VITE_API_BASE_URL || '',
   timeout: 300000, // 5 minute timeout (ontology generation may require longer time)
   headers: {
     'Content-Type': 'application/json'

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -689,13 +689,23 @@ onMounted(async () => {
   if (props.simulationId) {
     try {
       const res = await getRunStatus(props.simulationId)
-      if (res.success && res.data && res.data.runner_status === 'running') {
-        addLog('Simulation already running — resuming status polling')
-        runStatus.value = res.data
-        phase.value = 1
-        startStatusPolling()
-        startDetailPolling()
-        return
+      if (res.success && res.data) {
+        const status = res.data.runner_status
+        if (status === 'running') {
+          addLog('Simulation already running — resuming status polling')
+          runStatus.value = res.data
+          phase.value = 1
+          startStatusPolling()
+          startDetailPolling()
+          return
+        }
+        if (status === 'completed' || status === 'stopped') {
+          addLog(`Simulation ${status} — loading results`)
+          runStatus.value = res.data
+          phase.value = 2
+          emit('update-status', 'completed')
+          return
+        }
       }
     } catch (e) {
       // No running simulation found, safe to start

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -704,6 +704,7 @@ onMounted(async () => {
           runStatus.value = res.data
           phase.value = 2
           emit('update-status', 'completed')
+          fetchRunStatusDetail()
           return
         }
       }

--- a/frontend/src/components/Step3Simulation.vue
+++ b/frontend/src/components/Step3Simulation.vue
@@ -395,7 +395,7 @@ const doStartSimulation = async () => {
     const params = {
       simulation_id: props.simulationId,
       platform: 'parallel',
-      force: true,  // Force restart
+      force: false,
       enable_graph_memory_update: true  // Enable dynamic graph update
     }
 
@@ -684,9 +684,22 @@ watch(() => props.systemLogs?.length, () => {
   })
 })
 
-onMounted(() => {
+onMounted(async () => {
   addLog('Step3 Simulation initialization')
   if (props.simulationId) {
+    try {
+      const res = await getRunStatus(props.simulationId)
+      if (res.success && res.data && res.data.runner_status === 'running') {
+        addLog('Simulation already running — resuming status polling')
+        runStatus.value = res.data
+        phase.value = 1
+        startStatusPolling()
+        startDetailPolling()
+        return
+      }
+    } catch (e) {
+      // No running simulation found, safe to start
+    }
     doStartSimulation()
   }
 })

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,12 +5,18 @@ import SimulationView from '../views/SimulationView.vue'
 import SimulationRunView from '../views/SimulationRunView.vue'
 import ReportView from '../views/ReportView.vue'
 import InteractionView from '../views/InteractionView.vue'
+import DashboardView from '../views/DashboardView.vue'
 
 const routes = [
   {
     path: '/',
     name: 'Home',
     component: Home
+  },
+  {
+    path: '/dashboard',
+    name: 'Dashboard',
+    component: DashboardView
   },
   {
     path: '/process/:projectId',

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,0 +1,712 @@
+<template>
+  <div class="dashboard-container">
+    <nav class="dash-navbar">
+      <div class="dash-nav-brand" @click="$router.push('/')">MIROFISH OFFLINE</div>
+      <div class="dash-nav-links">
+        <router-link to="/" class="dash-nav-link">Home</router-link>
+        <router-link to="/dashboard" class="dash-nav-link active">Dashboard</router-link>
+      </div>
+    </nav>
+
+    <div class="dash-content">
+      <!-- Active Now Section -->
+      <section class="dash-section">
+        <div class="dash-section-header">
+          <span class="dash-section-dot">&#9632;</span>
+          <span class="dash-section-label">Active Now</span>
+          <span v-if="activeSimulations.length > 0" class="dash-active-count">{{ activeSimulations.length }}</span>
+        </div>
+
+        <div v-if="activeSimulations.length > 0" class="active-cards">
+          <div v-for="sim in activeSimulations" :key="sim.simulation_id" class="active-card">
+            <div class="active-card-header">
+              <span class="active-id">{{ formatId(sim.simulation_id) }}</span>
+              <span class="status-pill running">
+                <span class="pulse-dot"></span> Running
+              </span>
+            </div>
+
+            <div class="active-requirement">{{ truncate(sim.simulation_requirement, 60) || 'No description' }}</div>
+
+            <div class="active-platforms">
+              <span class="platform-tag">Twitter</span>
+              <span class="platform-tag">Reddit</span>
+            </div>
+
+            <div class="progress-section">
+              <div class="progress-label">
+                <span>Round {{ sim.current_round || 0 }} / {{ sim.total_rounds || '?' }}</span>
+                <span class="progress-pct">{{ getProgress(sim) }}%</span>
+              </div>
+              <div class="progress-track">
+                <div class="progress-fill" :style="{ width: getProgress(sim) + '%' }"></div>
+              </div>
+            </div>
+
+            <div class="active-meta">
+              <span class="meta-item">{{ sim.entities_count || 0 }} agents</span>
+              <span class="meta-sep">|</span>
+              <span class="meta-item">{{ formatDateShort(sim.created_at) }}</span>
+            </div>
+
+            <div class="active-actions">
+              <button class="action-btn view-btn" @click="goToSimRun(sim)">View</button>
+              <button class="action-btn stop-btn" @click="handleStop(sim)">Stop</button>
+            </div>
+          </div>
+        </div>
+
+        <div v-else class="empty-active">
+          <span class="empty-icon">&#9671;</span>
+          <span class="empty-text">No active simulations</span>
+          <router-link to="/" class="start-link">Start one &rarr;</router-link>
+        </div>
+      </section>
+
+      <!-- All Simulations Section -->
+      <section class="dash-section">
+        <div class="dash-section-header">
+          <span class="dash-section-dot">&#9671;</span>
+          <span class="dash-section-label">All Simulations</span>
+          <span class="dash-total-count">{{ filteredSimulations.length }}</span>
+        </div>
+
+        <div class="filter-bar">
+          <input
+            v-model="searchQuery"
+            class="filter-input"
+            type="text"
+            placeholder="Search by ID or requirement..."
+          />
+          <div class="filter-tabs">
+            <button
+              v-for="tab in statusTabs"
+              :key="tab.value"
+              class="filter-tab"
+              :class="{ active: activeTab === tab.value }"
+              @click="activeTab = tab.value"
+            >{{ tab.label }}</button>
+          </div>
+        </div>
+
+        <div v-if="loading && allSimulations.length === 0" class="table-loading">Loading...</div>
+
+        <div v-else-if="filteredSimulations.length === 0" class="table-empty">
+          No simulations found
+        </div>
+
+        <div v-else class="sim-table-wrap">
+          <table class="sim-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Requirement</th>
+                <th>Status</th>
+                <th>Progress</th>
+                <th>Agents</th>
+                <th>Created</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="sim in filteredSimulations" :key="sim.simulation_id">
+                <td class="cell-id">{{ formatId(sim.simulation_id) }}</td>
+                <td class="cell-req">{{ truncate(sim.simulation_requirement, 50) || '---' }}</td>
+                <td>
+                  <span class="status-pill" :class="getStatusClass(sim)">
+                    <span class="status-dot-sm">&#9679;</span> {{ getStatusLabel(sim) }}
+                  </span>
+                </td>
+                <td class="cell-progress">
+                  <span class="progress-text">{{ sim.current_round || 0 }}/{{ sim.total_rounds || '?' }}</span>
+                  <div class="mini-progress-track">
+                    <div class="mini-progress-fill" :style="{ width: getProgress(sim) + '%' }"></div>
+                  </div>
+                </td>
+                <td class="cell-num">{{ sim.entities_count || 0 }}</td>
+                <td class="cell-date">{{ formatDateShort(sim.created_at) }}</td>
+                <td class="cell-actions">
+                  <button
+                    v-if="sim.project_id"
+                    class="tbl-btn"
+                    title="Graph"
+                    @click="$router.push({ name: 'Process', params: { projectId: sim.project_id } })"
+                  >&#9671;</button>
+                  <button
+                    class="tbl-btn"
+                    title="Simulation"
+                    @click="goToSimRun(sim)"
+                  >&#9672;</button>
+                  <button
+                    v-if="sim.report_id"
+                    class="tbl-btn"
+                    title="Report"
+                    @click="$router.push({ name: 'Report', params: { reportId: sim.report_id } })"
+                  >&#9670;</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { getSimulationHistory, stopSimulation } from '../api/simulation'
+
+const router = useRouter()
+
+const allSimulations = ref([])
+const loading = ref(true)
+const searchQuery = ref('')
+const activeTab = ref('all')
+let pollTimer = null
+
+const statusTabs = [
+  { label: 'All', value: 'all' },
+  { label: 'Running', value: 'running' },
+  { label: 'Completed', value: 'completed' },
+  { label: 'Stopped', value: 'stopped' },
+]
+
+const activeSimulations = computed(() =>
+  allSimulations.value.filter(s => s.runner_status === 'running')
+)
+
+const filteredSimulations = computed(() => {
+  let list = allSimulations.value
+
+  if (activeTab.value !== 'all') {
+    list = list.filter(s => getStatusKey(s) === activeTab.value)
+  }
+
+  if (searchQuery.value.trim()) {
+    const q = searchQuery.value.toLowerCase()
+    list = list.filter(s =>
+      (s.simulation_id || '').toLowerCase().includes(q) ||
+      (s.simulation_requirement || '').toLowerCase().includes(q)
+    )
+  }
+
+  return list
+})
+
+function getStatusKey(sim) {
+  if (sim.runner_status === 'running') return 'running'
+  if (sim.runner_status === 'completed' || sim.status === 'completed') return 'completed'
+  if (sim.runner_status === 'stopped') return 'stopped'
+  return 'idle'
+}
+
+function getStatusLabel(sim) {
+  const key = getStatusKey(sim)
+  return key.charAt(0).toUpperCase() + key.slice(1)
+}
+
+function getStatusClass(sim) {
+  return getStatusKey(sim)
+}
+
+function getProgress(sim) {
+  if (!sim.total_rounds || sim.total_rounds === 0) return 0
+  return Math.min(100, Math.round(((sim.current_round || 0) / sim.total_rounds) * 100))
+}
+
+function formatId(id) {
+  if (!id) return '---'
+  return id.length > 12 ? id.slice(0, 12) + '...' : id
+}
+
+function truncate(text, max) {
+  if (!text) return ''
+  return text.length > max ? text.slice(0, max) + '...' : text
+}
+
+function formatDateShort(dateStr) {
+  if (!dateStr) return '---'
+  try {
+    const d = new Date(dateStr)
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return dateStr.slice(0, 10)
+  }
+}
+
+function goToSimRun(sim) {
+  router.push({ name: 'SimulationRun', params: { simulationId: sim.simulation_id } })
+}
+
+async function fetchData() {
+  try {
+    const res = await getSimulationHistory(50)
+    if (res.success && res.data) {
+      allSimulations.value = res.data
+    }
+  } catch (e) {
+    console.error('Failed to fetch simulations:', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleStop(sim) {
+  if (!confirm(`Stop simulation ${formatId(sim.simulation_id)}?`)) return
+  try {
+    await stopSimulation({ simulation_id: sim.simulation_id })
+    await fetchData()
+  } catch (e) {
+    console.error('Failed to stop simulation:', e)
+  }
+}
+
+onMounted(() => {
+  fetchData()
+  pollTimer = setInterval(fetchData, 3000)
+})
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer)
+})
+</script>
+
+<style scoped>
+.dashboard-container {
+  min-height: 100vh;
+  background: #fff;
+  font-family: 'Space Grotesk', 'Noto Sans SC', system-ui, sans-serif;
+  color: #111;
+}
+
+/* Navbar */
+.dash-navbar {
+  height: 60px;
+  background: #000;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 40px;
+}
+.dash-nav-brand {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 800;
+  letter-spacing: 1px;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+.dash-nav-links {
+  display: flex;
+  gap: 24px;
+}
+.dash-nav-link {
+  color: #888;
+  text-decoration: none;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+.dash-nav-link:hover,
+.dash-nav-link.active {
+  color: #fff;
+}
+
+/* Content */
+.dash-content {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 40px 40px 80px;
+}
+
+/* Section Headers */
+.dash-section {
+  margin-bottom: 50px;
+}
+.dash-section-header {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #999;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.dash-section-dot {
+  color: #FF4500;
+  font-size: 0.8rem;
+}
+.dash-active-count,
+.dash-total-count {
+  background: #f0f0f0;
+  color: #333;
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  border-radius: 2px;
+}
+.dash-active-count {
+  background: #FF4500;
+  color: #fff;
+}
+
+/* Active Cards */
+.active-cards {
+  display: flex;
+  gap: 20px;
+  overflow-x: auto;
+  padding-bottom: 10px;
+}
+.active-card {
+  min-width: 320px;
+  max-width: 380px;
+  border: 1px solid #e0e0e0;
+  padding: 24px;
+  flex-shrink: 0;
+  position: relative;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+.active-card:hover {
+  border-color: #FF4500;
+  box-shadow: 0 0 0 1px #FF4500;
+}
+.active-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.active-id {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #666;
+}
+.active-requirement {
+  font-size: 0.9rem;
+  color: #333;
+  line-height: 1.5;
+  margin-bottom: 12px;
+  min-height: 40px;
+}
+.active-platforms {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.platform-tag {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  padding: 3px 8px;
+  border: 1px solid #ddd;
+  color: #666;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.progress-section {
+  margin-bottom: 12px;
+}
+.progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #666;
+  margin-bottom: 6px;
+}
+.progress-pct {
+  color: #FF4500;
+  font-weight: 700;
+}
+.progress-track {
+  height: 4px;
+  background: #f0f0f0;
+  width: 100%;
+}
+.progress-fill {
+  height: 100%;
+  background: #FF4500;
+  transition: width 0.5s ease;
+}
+.active-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: #999;
+  margin-bottom: 16px;
+  display: flex;
+  gap: 6px;
+}
+.meta-sep {
+  color: #ddd;
+}
+.active-actions {
+  display: flex;
+  gap: 10px;
+}
+.action-btn {
+  flex: 1;
+  padding: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  letter-spacing: 0.5px;
+  transition: opacity 0.2s;
+}
+.action-btn:hover {
+  opacity: 0.85;
+}
+.view-btn {
+  background: #000;
+  color: #fff;
+}
+.stop-btn {
+  background: transparent;
+  color: #FF4500;
+  border: 1px solid #FF4500;
+}
+
+/* Status Pills */
+.status-pill {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  padding: 3px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border-radius: 2px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+.status-pill.running {
+  background: rgba(34, 197, 94, 0.1);
+  color: #16a34a;
+}
+.status-pill.completed {
+  background: rgba(59, 130, 246, 0.1);
+  color: #2563eb;
+}
+.status-pill.stopped {
+  background: rgba(107, 114, 128, 0.1);
+  color: #6b7280;
+}
+.status-pill.idle {
+  background: rgba(107, 114, 128, 0.05);
+  color: #9ca3af;
+}
+.status-dot-sm {
+  font-size: 0.5rem;
+}
+.pulse-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #16a34a;
+  display: inline-block;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(22, 163, 106, 0.4); }
+  50% { opacity: 0.7; box-shadow: 0 0 0 4px rgba(22, 163, 106, 0); }
+}
+
+/* Empty Active */
+.empty-active {
+  border: 1px dashed #ddd;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: #999;
+}
+.empty-icon {
+  font-size: 1.5rem;
+  color: #ccc;
+}
+.empty-text {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+}
+.start-link {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #FF4500;
+  text-decoration: none;
+  font-weight: 600;
+}
+.start-link:hover {
+  text-decoration: underline;
+}
+
+/* Filter Bar */
+.filter-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  gap: 16px;
+}
+.filter-input {
+  flex: 1;
+  max-width: 400px;
+  padding: 10px 14px;
+  border: 1px solid #e0e0e0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  outline: none;
+  background: #fafafa;
+  transition: border-color 0.2s;
+}
+.filter-input:focus {
+  border-color: #999;
+}
+.filter-input::placeholder {
+  color: #bbb;
+}
+.filter-tabs {
+  display: flex;
+  gap: 0;
+}
+.filter-tab {
+  padding: 8px 16px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid #e0e0e0;
+  background: transparent;
+  color: #999;
+  transition: all 0.2s;
+  margin-left: -1px;
+}
+.filter-tab:first-child {
+  margin-left: 0;
+}
+.filter-tab.active {
+  background: #000;
+  color: #fff;
+  border-color: #000;
+  z-index: 1;
+  position: relative;
+}
+.filter-tab:hover:not(.active) {
+  color: #333;
+  background: #f5f5f5;
+}
+
+/* Table */
+.sim-table-wrap {
+  border: 1px solid #e0e0e0;
+  overflow-x: auto;
+}
+.sim-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.sim-table thead {
+  background: #fafafa;
+}
+.sim-table th {
+  text-align: left;
+  padding: 12px 16px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #999;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid #e0e0e0;
+  white-space: nowrap;
+}
+.sim-table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid #f0f0f0;
+  vertical-align: middle;
+}
+.sim-table tbody tr:hover {
+  background: #fafafa;
+}
+.sim-table tbody tr:last-child td {
+  border-bottom: none;
+}
+.cell-id {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #666;
+  white-space: nowrap;
+}
+.cell-req {
+  color: #333;
+  max-width: 300px;
+}
+.cell-progress {
+  white-space: nowrap;
+}
+.progress-text {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #666;
+  display: block;
+  margin-bottom: 4px;
+}
+.mini-progress-track {
+  height: 3px;
+  background: #f0f0f0;
+  width: 80px;
+}
+.mini-progress-fill {
+  height: 100%;
+  background: #FF4500;
+  transition: width 0.5s ease;
+}
+.cell-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #666;
+  text-align: center;
+}
+.cell-date {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #999;
+  white-space: nowrap;
+}
+.cell-actions {
+  display: flex;
+  gap: 6px;
+}
+.tbl-btn {
+  width: 30px;
+  height: 30px;
+  border: 1px solid #e0e0e0;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: #999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+.tbl-btn:hover {
+  border-color: #000;
+  color: #000;
+}
+
+.table-loading,
+.table-empty {
+  padding: 40px;
+  text-align: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  color: #999;
+  border: 1px solid #e0e0e0;
+}
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -4,6 +4,7 @@
     <nav class="navbar" :style="s.navbar">
       <div class="nav-brand" :style="s.navBrand">MIROFISH OFFLINE</div>
       <div class="nav-links" :style="s.navLinks">
+        <router-link to="/dashboard" :style="s.dashLink">Dashboard</router-link>
         <a href="https://github.com/nikmcfly/MiroFish-Offline" target="_blank" class="github-link" :style="s.githubLink">
           Visit our Github <span>↗</span>
         </a>
@@ -154,7 +155,8 @@ const sans = 'Space Grotesk, Noto Sans SC, system-ui, sans-serif'
 const s = reactive({
   navbar: { height: '60px', background: '#000', color: '#fff', display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 40px' },
   navBrand: { fontFamily: mono, fontWeight: '800', letterSpacing: '1px', fontSize: '1.2rem' },
-  navLinks: { display: 'flex', alignItems: 'center' },
+  navLinks: { display: 'flex', alignItems: 'center', gap: '24px' },
+  dashLink: { color: '#fff', textDecoration: 'none', fontFamily: mono, fontSize: '0.9rem', fontWeight: '500' },
   githubLink: { color: '#fff', textDecoration: 'none', fontFamily: mono, fontSize: '0.9rem', fontWeight: '500', display: 'flex', alignItems: 'center', gap: '8px' },
   mainContent: { maxWidth: '1400px', margin: '0 auto', padding: '60px 40px' },
   heroSection: { display: 'flex', justifyContent: 'space-between', marginBottom: '80px', position: 'relative' },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,8 +5,10 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   server: {
-    port: 3000,
-    open: true,
+    host: '0.0.0.0',
+    port: 3001,
+    open: false,
+    allowedHosts: ['wealthiq.ngrok.app'],
     proxy: {
       '/api': {
         target: 'http://localhost:5001',

--- a/future_features.md
+++ b/future_features.md
@@ -1,0 +1,167 @@
+# MiroFish — Future Features (Proprietary)
+
+Internal roadmap for simulation capabilities beyond the open-source base.
+Do NOT push this file to nikmcfly/MiroFish-Offline.
+
+---
+
+## 1. Mid-Simulation Event Injection
+
+**Goal**: Drop breaking news or new narratives into a running simulation and watch agents react in real-time.
+
+**Why**: The current system only injects seed posts at round 0 via `event_config.initial_posts`. Once the simulation starts, you can't introduce new variables. This makes it impossible to test "what if X happens on day 3?"
+
+**Architecture**:
+
+```
+Frontend (button)
+    → POST /api/simulation/:id/inject-event
+        → SimulationIPCClient writes to ipc_commands/
+            → run_parallel_simulation.py polls and picks it up
+                → ManualAction(CREATE_POST, content=...) for target agent
+                    → Other agents react via LLM in subsequent rounds
+```
+
+**Changes needed**:
+
+| File | Change |
+|------|--------|
+| `backend/app/services/simulation_ipc.py` | Add `INJECT_EVENT` to `CommandType` enum |
+| `backend/scripts/run_parallel_simulation.py` | Handle `INJECT_EVENT` in `process_commands()` — create a `ManualAction(CREATE_POST)` for the specified agent and inject it into the next round |
+| `backend/app/services/simulation_runner.py` | Add `inject_event()` classmethod that writes the IPC command |
+| `backend/app/api/simulation.py` | Add `POST /api/simulation/<id>/inject-event` endpoint accepting `{ agent_id, content, platform }` |
+| `frontend/src/components/Step3Simulation.vue` | Add "Inject Event" button/modal in the simulation control panel |
+
+**IPC command format**:
+```json
+{
+  "command_id": "evt_xxxx",
+  "command_type": "inject_event",
+  "args": {
+    "platform": "twitter",
+    "agent_id": 0,
+    "content": "BREAKING: Iran launches second wave of missile strikes...",
+    "round_delay": 0
+  }
+}
+```
+
+**Considerations**:
+- Agent selection: which agent posts the breaking news? Could be a "Reality Seed" agent (narrator) or any agent
+- Multiple events: support queuing multiple injections for different rounds
+- Graph impact: injected events should flow through GraphMemoryUpdater like normal actions
+- Could support `round_delay: N` to schedule injection N rounds from now
+
+---
+
+## 2. Simulation Resume / Continue
+
+**Goal**: Pick up a completed simulation and keep running more rounds, preserving all existing state.
+
+**Why**: A 7-day simulation might reveal early trends, but you want to see what happens at 30 or 90 days without re-running from scratch. Currently, starting a simulation always resets to round 0.
+
+**Architecture**:
+
+```
+POST /api/simulation/:id/start { resume: true, additional_rounds: 200 }
+    → SimulationRunner checks for existing SQLite DBs and actions.jsonl
+    → Passes --resume flag to run_parallel_simulation.py
+    → Script skips environment init, loads existing DB state
+    → Starts from last_round + 1, appends to existing action logs
+```
+
+**Changes needed**:
+
+| File | Change |
+|------|--------|
+| `backend/scripts/run_parallel_simulation.py` | Add `--resume` CLI flag. When set: skip `env.reset()`, load existing SQLite DB, read last round number from actions.jsonl, start loop from `last_round + 1` |
+| `backend/app/services/simulation_runner.py` | In `start_simulation()`: if `resume=True`, don't clean files, pass `--resume` and `--start-round N` to subprocess. Update `total_rounds` to old + additional |
+| `backend/app/api/simulation.py` | In `/start` endpoint: accept `resume: true` and `additional_rounds` params. Skip cleanup when resuming |
+| `frontend/src/components/Step3Simulation.vue` | After simulation completes, show "Continue Simulation" button with rounds input |
+
+**Key challenges**:
+- OASIS environment state lives in SQLite — need to verify it can be loaded without `env.reset()`
+- Agent memory/context from previous rounds must persist (stored in DB, should work)
+- `run_state.json` needs to reflect cumulative totals, not reset
+- Action log must append, not overwrite
+
+---
+
+## 3. Narrative Stacking (Multi-Document Scenarios)
+
+**Goal**: Add a second (or third) document mid-simulation to layer new narratives on top of the existing one.
+
+**Why**: Real-world scenarios don't happen in isolation. You might start with "Iran conflict impact on Dubai real estate" and then want to add "Saudi Arabia announces Vision 2030 mega-project" to see compound effects.
+
+**Architecture**:
+
+```
+POST /api/simulation/:id/add-narrative
+    → Upload new document (PDF/MD/TXT)
+    → Run through existing NER/graph pipeline → new entities + relations added to same graph_id
+    → Generate new seed posts from the document
+    → Inject those posts via Event Injection (feature #1)
+    → Agents now have both the original + new context in their graph memory
+```
+
+**Changes needed**:
+
+| File | Change |
+|------|--------|
+| `backend/app/api/simulation.py` | Add `POST /api/simulation/<id>/add-narrative` endpoint |
+| `backend/app/storage/neo4j_storage.py` | `add_text()` already supports appending to existing graph — no change needed |
+| `backend/app/services/graph_memory_updater.py` | No change — new entities merge into existing graph |
+| New: narrative injection service | Orchestrates: ingest doc → extract entities → generate seed posts → inject via IPC |
+| Frontend | "Add Narrative" button in simulation panel, file upload + preview |
+
+**This builds on features #1 and #2**: you need event injection to post the new narrative's seed content, and ideally resume so the simulation continues with the new context.
+
+---
+
+## 4. Comparative Simulation Runs
+
+**Goal**: Run the same scenario with different variables (e.g., "with sanctions" vs "without sanctions") and compare outcomes side-by-side.
+
+**Why**: The real value of simulation is counterfactual analysis. "What would have happened if Iran didn't retaliate?" requires running two parallel worlds from the same starting point.
+
+**Architecture**:
+- Fork a simulation at a specific round (copy SQLite DBs + action logs up to round N)
+- Run variant B from that fork point with a different injected event (or no event)
+- Dashboard shows both runs side-by-side with divergence metrics
+
+**Changes needed**:
+- `POST /api/simulation/:id/fork` — copies sim data to a new sim_id
+- Resume (feature #2) from the fork point
+- Dashboard comparison view — two simulations' timelines aligned by round
+- Divergence metrics: sentiment drift, agent behavior changes, topic distribution shifts
+
+---
+
+## 5. Real-Time Agent Memory Inspection
+
+**Goal**: During a running simulation, query what any agent "knows" and "believes" based on their accumulated graph memory.
+
+**Why**: Understanding WHY an agent posts what it posts. Currently you can interview agents, but you can't see their internal knowledge state.
+
+**Architecture**:
+- Query Neo4j for all episodes involving a specific agent
+- Show the entity/relation subgraph connected to that agent
+- Display the agent's "worldview" — what facts they've been exposed to, who they've interacted with
+
+**Partially exists**: The interview IPC command already works. This is more about visualization than new backend logic.
+
+---
+
+## Implementation Priority
+
+| # | Feature | Complexity | Value | Dependencies |
+|---|---------|-----------|-------|-------------|
+| 1 | Event Injection | Medium | High | None — IPC infra exists |
+| 2 | Simulation Resume | Medium | High | None |
+| 3 | Narrative Stacking | Medium | Very High | Requires #1 + #2 |
+| 4 | Comparative Runs | High | Very High | Requires #2 |
+| 5 | Agent Memory Inspection | Low | Medium | None |
+
+Recommended order: **1 → 2 → 5 → 3 → 4**
+
+Event injection is the quickest win and unlocks the most interesting scenarios. Resume is essential for longer simulations and enables narrative stacking and comparative runs.


### PR DESCRIPTION
## Summary

While self-hosting MiroFish-Offline on a 4x GPU Linux server, we discovered that **refreshing the browser kills the running simulation and permanently deletes all data**. This PR fixes the root cause (two compounding bugs) plus related issues found during debugging, adds a dashboard view to monitor simulations, and fixes orphaned simulation recovery on backend restart.

### The kill chain (before this PR)

1. `Step3Simulation.vue` `onMounted()` calls `doStartSimulation()` unconditionally on every page load
2. `doStartSimulation()` has `force: true` hardcoded, telling the backend to kill any running process
3. Backend kills the simulation subprocess, deletes all runtime files (action logs, SQLite DBs, run state)
4. Backend starts a new simulation from round 0
5. All previous progress is permanently lost

### Bug fixes

- **Frontend: check before starting** — `onMounted` now calls `getRunStatus()` first; if the simulation is already running, it resumes status polling instead of restarting (`Step3Simulation.vue`)
- **Frontend: don't force by default** — changed `force: true` to `force: false` in the default start path (`Step3Simulation.vue`)
- **Backend: pass GraphStorage to subprocess** — the `/start` endpoint was calling `SimulationRunner.start_simulation()` without the `storage` parameter, so `GraphMemoryUpdater` threw "Must provide storage" and graph updates silently failed. Now fetches `neo4j_storage` from Flask context and passes it through (`simulation.py`)
- **Backend: preserve state.json on "already running"** — when `/start` returns 400 for an already-running simulation, `state.json` is now saved with `status: "running"` before returning the error, preventing a desync where the frontend sees "ready" and retries in a loop (`simulation.py`)
- **Backend: clear Neo4j on force-restart** — `cleanup_simulation_logs()` now accepts optional `storage` and `graph_id` parameters to clear stale graph data during force-restart (`simulation_runner.py`)
- **Backend: reconnect to orphaned simulations on restart** — when the backend restarts (crash, debug auto-reload, manual restart), the monitor thread that updates `run_state.json` dies while the simulation subprocess keeps running. On startup, `SimulationRunner.reconnect_orphaned_simulations()` now scans for simulations with `runner_status="running"`, checks if the PID is still alive, and starts a new monitor thread to resume reading action logs and updating state. Dead processes are marked as stopped. (`simulation_runner.py`, `__init__.py`)
- **Backend: reconnect GraphMemoryUpdater for orphaned simulations** — the orphan reconnect was recovering the monitor thread but not the `GraphMemoryUpdater`, so graph updates stopped after any backend restart. Now reads `graph_id` from `state.json`, creates a fresh `Neo4jStorage` connection, and restarts the updater so simulation actions continue flowing into the knowledge graph. (`simulation_runner.py`)
- **Backend: fix duplicate graph episodes on reconnect** — the orphan monitor started reading action logs from position 0 on every backend restart, re-feeding all actions to GraphMemoryUpdater and creating duplicate episodes in Neo4j. Now starts from end of existing log files so only new actions are processed. (`simulation_runner.py`)

### Additional fixes (found during debugging)

- Bumped default LLM context window from 8192 to 32768 tokens (`llm_client.py`)
- Added traceback logging for ontology generation failures (`graph.py`)
- Filter malformed entity/edge types missing the `name` key before validation (`ontology_generator.py`)

### New feature: Simulation Dashboard (`/dashboard`)

Built to verify that the bug fixes were working — turned out to be a useful feature:

- **Active Now** section with live-updating cards for running simulations (progress bars, round counts, stop/view actions, 3s polling)
- **All Simulations** history table with search input and status filter tabs (All / Running / Completed / Stopped)
- Navigation to Graph, Simulation Run, and Report views per simulation
- Matches existing design language (Space Grotesk, JetBrains Mono, custom CSS, no new dependencies)
- Link added to Home navbar

## Test plan

- [x] Start a simulation, refresh the browser — simulation continues running (not killed)
- [x] Dashboard shows running simulation with live progress updates
- [x] GraphMemoryUpdater writes to Neo4j during simulation (verified: 51 entities, 20 relations, 25 episodes)
- [x] Calling `/start` with `force: false` on a running simulation returns 400 without killing it
- [x] Restart backend while simulation is running — backend reconnects and resumes monitoring automatically
- [x] Restart backend — GraphMemoryUpdater reconnects and graph updates resume
- [x] Restart backend multiple times — no duplicate graph episodes created
- [x] Dashboard filter tabs and search work correctly
- [x] Navigation from dashboard cards to simulation/report views works