### PR TITLE
fix: handle nested response object in report agent chat

### DIFF
--- a/frontend/src/components/Step5Interaction.vue
+++ b/frontend/src/components/Step5Interaction.vue
@@ -697,7 +697,7 @@ const sendToReportAgent = async (message) => {
   if (res.success && res.data) {
     chatHistory.value.push({
       role: 'assistant',
-      content: res.data.response || res.data.answer || 'No response',
+      content: (typeof res.data.response === 'object' ? res.data.response.response : res.data.response) || res.data.answer || 'No response',
       timestamp: new Date().toISOString()
     })
     addLog('Report Agent replied')


### PR DESCRIPTION
## Summary
- The `/api/report/chat` endpoint returns a nested response: `{data: {response: {response: "text", sources: [], tool_calls: []}}}`
- The frontend (`Step5Interaction.vue`) expected `res.data.response` to be a string, but it's an object
- This caused the chat UI to spin indefinitely as the object couldn't be rendered as message content

## Fix
Added type check to extract the inner string when `res.data.response` is an object:
```js
// Before
content: res.data.response || res.data.answer || 'No response',

// After
content: (typeof res.data.response === 'object' ? res.data.response.response : res.data.response) || res.data.answer || 'No response',
```

## Test plan
- [x] Verified `/api/report/chat` returns nested `{response: {response: "..."}}` structure
- [x] Confirmed chat messages now render correctly after the fix