### PR TITLE
fix: deduplicate relation edges using MERGE instead of CREATE

### DIFF
--- a/backend/app/storage/neo4j_storage.py
+++ b/backend/app/storage/neo4j_storage.py
@@ -319,19 +319,21 @@ class Neo4jStorage(GraphStorage):
                         """
                         MATCH (src:Entity {uuid: $src_uuid})
                         MATCH (tgt:Entity {uuid: $tgt_uuid})
-                        CREATE (src)-[r:RELATION {
-                            uuid: $uuid,
-                            graph_id: $gid,
-                            name: $name,
-                            fact: $fact,
-                            fact_embedding: $fact_embedding,
-                            attributes_json: '{}',
-                            episode_ids: [$episode_id],
-                            created_at: $now,
-                            valid_at: null,
-                            invalid_at: null,
-                            expired_at: null
-                        }]->(tgt)
+                        MERGE (src)-[r:RELATION {graph_id: $gid, name: $name}]->(tgt)
+                        ON CREATE SET
+                            r.uuid = $uuid,
+                            r.fact = $fact,
+                            r.fact_embedding = $fact_embedding,
+                            r.attributes_json = '{}',
+                            r.episode_ids = [$episode_id],
+                            r.created_at = $now,
+                            r.valid_at = null,
+                            r.invalid_at = null,
+                            r.expired_at = null
+                        ON MATCH SET
+                            r.fact = $fact,
+                            r.fact_embedding = $fact_embedding,
+                            r.episode_ids = r.episode_ids + $episode_id
                         """,
                         src_uuid=_source_uuid,
                         tgt_uuid=_target_uuid,


### PR DESCRIPTION
## Summary
- Entity nodes use `MERGE` to prevent duplicates, but relation edges use `CREATE` — causing duplicate edges when the same (source, relation_type, target) appears across multiple text chunks
- Example: "person A works_for company B" mentioned in 4 chunks → 4 identical edges created

## Fix
Changed `CREATE` to `MERGE` keyed on `(graph_id, name)` between the same source/target nodes:
- `ON CREATE`: initializes all properties as before
- `ON MATCH`: updates fact/embedding and appends episode_id to the list

## Before
Multiple chunks mentioning the same relationship → duplicate edges in graph

## After
Same (source, relation, target) → single edge, enriched with all episode references

## Test plan
- [x] Verified single edge created for repeated "works_for" relationships across chunks
- [x] Confirmed episode_ids accumulate on matched edges