### PR TITLE
fix: disable thinking mode for structured JSON output requests

### DIFF
--- a/backend/app/services/oasis_profile_generator.py
+++ b/backend/app/services/oasis_profile_generator.py
@@ -478,7 +478,8 @@ class OasisProfileGenerator:
                         {"role": "user", "content": prompt}
                     ],
                     response_format={"type": "json_object"},
-                    temperature=0.7 - (attempt * 0.1)  # Lower temperature with each retry
+                    temperature=0.7 - (attempt * 0.1),  # Lower temperature with each retry
+                    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
                     # Don't set max_tokens, let LLM generate freely
                 )
 

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -72,12 +72,16 @@ class LLMClient:
 
         if response_format:
             kwargs["response_format"] = response_format
+            # Disable thinking mode (e.g. Qwen3 <think> tags) when requesting
+            # structured JSON output — thinking tokens break JSON parsing and
+            # cause infinite retry loops with vLLM's guided decoding.
+            kwargs.setdefault("extra_body", {})
+            kwargs["extra_body"]["chat_template_kwargs"] = {"enable_thinking": False}
 
         # For Ollama: pass num_ctx via extra_body to prevent prompt truncation
         if self._is_ollama() and self._num_ctx:
-            kwargs["extra_body"] = {
-                "options": {"num_ctx": self._num_ctx}
-            }
+            kwargs.setdefault("extra_body", {})
+            kwargs["extra_body"]["options"] = {"num_ctx": self._num_ctx}
 
         response = self.client.chat.completions.create(**kwargs)
         content = response.choices[0].message.content


### PR DESCRIPTION
## Summary
Models with reasoning/thinking capabilities (e.g. Qwen3 with `--reasoning-parser`) emit `<think>` tags before generating content. When combined with `response_format=json_object` and vLLM's guided decoding, this causes an **infinite abort-retry loop** — the thinking tokens violate the JSON schema, vLLM aborts, the client retries, and the process hangs indefinitely.

This blocks persona generation at ~50-53 out of 75 agents every time.

## Fix
Automatically sets `enable_thinking=false` via `chat_template_kwargs` whenever structured JSON output is requested, in both:
- `llm_client.py` (general LLM client used for ontology generation etc.)
- `oasis_profile_generator.py` (agent persona generation)

## Test plan
- [x] Verified persona generation completes all 75/75 agents without hanging
- [x] Confirmed JSON responses are valid without `<think>` tag contamination
- [x] Non-JSON requests (chat, report) still use thinking mode normally