### PR TITLE
fix: fall back to Ollama native /api/chat for thinking-mode models (fixes #26)

### DIFF
--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -9,6 +9,7 @@ import os
 import re
 from typing import Optional, Dict, Any, List
 from openai import OpenAI
+import requests
 
 from ..config import Config
 
@@ -43,6 +44,39 @@ class LLMClient:
     def _is_ollama(self) -> bool:
         """Check if we're talking to an Ollama server."""
         return '11434' in (self.base_url or '')
+
+    def _ollama_native_base(self) -> str:
+        """Return the Ollama host base URL (strips /v1 suffix)."""
+        base = (self.base_url or '').rstrip('/')
+        if base.endswith('/v1'):
+            base = base[:-3]
+        return base
+
+    def _chat_via_ollama_native(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float,
+    ) -> str:
+        """
+        Fallback: call Ollama's native /api/chat endpoint.
+
+        Used when the OpenAI-compatible endpoint returns empty content for
+        thinking-mode models (e.g. Gemma 4) whose <|think|> tokens consume
+        the max_tokens budget before any visible content is produced.
+        """
+        url = f"{self._ollama_native_base()}/api/chat"
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "stream": False,
+            "options": {
+                "temperature": temperature,
+                "num_ctx": self._num_ctx,
+            },
+        }
+        resp = requests.post(url, json=payload, timeout=300)
+        resp.raise_for_status()
+        return resp.json()["message"]["content"]
 
     def chat(
         self,
@@ -81,8 +115,16 @@ class LLMClient:
 
         response = self.client.chat.completions.create(**kwargs)
         content = response.choices[0].message.content
+
+        # Thinking-mode models (e.g. Gemma 4) can exhaust max_tokens on internal
+        # reasoning tokens, causing Ollama's OpenAI-compat layer to return empty
+        # content.  Fall back to the native /api/chat endpoint which surfaces the
+        # visible response correctly.
+        if not content and self._is_ollama():
+            content = self._chat_via_ollama_native(messages, temperature)
+
         # Some models (like MiniMax M2.5) include <think>thinking content in response, need to remove
-        content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
+        content = re.sub(r'<think>[\s\S]*?</think>', '', content or '').strip()
         return content
 
     def chat_json(


### PR DESCRIPTION
## Problem

Thinking-mode models (e.g. `gemma4:26b`) generate internal `<|think|>` reasoning tokens that exhaust `max_tokens` before producing visible content. Ollama's OpenAI-compatible `/v1/chat/completions` endpoint strips those tokens and returns empty `content`, causing 500 errors when starting simulations.

## Fix

In `LLMClient.chat()`, after calling the OpenAI-compat endpoint, check if `content` is empty. If it is and we're talking to an Ollama server, retry via the native `/api/chat` endpoint, which surfaces the visible response correctly.

Changes in `backend/app/utils/llm_client.py`:
- Added `_ollama_native_base()` — strips `/v1` suffix to get the Ollama host URL
- Added `_chat_via_ollama_native()` — POSTs to `/api/chat` with stream=false, carries over `temperature` and `num_ctx`
- In `chat()`: triggers the fallback only when `content` is falsy **and** `_is_ollama()` is true — fully backwards-compatible, zero impact on non-Ollama or non-thinking-mode models
- Fixed a latent `NoneType` crash: `re.sub(…, content or '')` guards against `None` content even without the fallback

## Test plan

- [ ] Run a simulation with a standard model (e.g. `qwen2.5:32b`) — behaviour unchanged
- [ ] Run a simulation with `gemma4:26b` — should now return visible response instead of 500
- [ ] Verify `_ollama_native_base()` strips `/v1` from `http://localhost:11434/v1` correctly
- [ ] Non-Ollama endpoints (OpenAI, etc.) are unaffected — fallback never fires

Fixes #26