### PR TITLE
fix: bump pinned deps to versions with macOS ARM wheels

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -53,3 +53,11 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]
+
+[tool.uv]
+override-dependencies = [
+    "tiktoken==0.8.0",
+    "pillow>=10.4.0",
+    "pandas>=2.2.3"
+
+]


### PR DESCRIPTION
This PR addresses some python library version issues encountered when running on Apple Silicon.
 
`tiktoken`, `pillow`, and `pandas` were pinned to versions without pre-built wheels for macOS ARM64, causing source builds to fail. 

Bumped to nearest patch versions with wheels available.

Testing completed: Ran a simulation successfully with 15 agents and Neo4j with 14b model