### PR TITLE
docs: add RS2000 cloud smoke profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 <img src="./static/image/mirofish-offline-banner.png" alt="MiroFish Offline" width="100%"/>
 
+# MiroFish-Online
+
+This fork tracks [`nikmcfly/MiroFish-Offline`](https://github.com/nikmcfly/MiroFish-Offline) and prepares a private RS2000 deployment profile for Piotr's platform: cloud LLM inference, local graph storage, and Tailnet-only exposure.
+
+See [`docs/rs2000-smoke.md`](docs/rs2000-smoke.md) for the platform-specific smoke profile. The upstream README below remains the baseline project documentation.
+
+---
+
 # MiroFish-Offline
 
 **Fully local fork of [MiroFish](https://github.com/666ghj/MiroFish) — no cloud APIs required. English UI.**

--- a/deploy/rs2000/.env.example
+++ b/deploy/rs2000/.env.example
@@ -1,0 +1,36 @@
+# MiroFish Online — RS2000 smoke profile
+# Copy to the runtime .env rendered from Infisical. Do not commit real values.
+
+# Flask / runtime
+SECRET_KEY=replace-with-infisical-secret
+FLASK_DEBUG=false
+OASIS_DEFAULT_MAX_ROUNDS=8
+REPORT_AGENT_MAX_TOOL_CALLS=5
+REPORT_AGENT_MAX_REFLECTION_ROUNDS=2
+
+# LLM: cloud OpenAI-compatible endpoint.
+# Use one of:
+#   qwen3.5:cloud
+#   qwen3.5:397b-cloud
+LLM_API_KEY=replace-with-ollama-cloud-api-key
+LLM_BASE_URL=https://ollama.com/v1
+LLM_MODEL_NAME=qwen3.5:cloud
+
+# CAMEL/OASIS reads OpenAI-compatible variables separately.
+OPENAI_API_KEY=replace-with-ollama-cloud-api-key
+OPENAI_API_BASE_URL=https://ollama.com/v1
+
+# Neo4j is private to Docker network in the RS2000 smoke compose.
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=replace-with-infisical-neo4j-password
+
+# Embeddings are currently implemented against Ollama /api/embed.
+# Ollama Cloud does not provide the embedding endpoint we need here, so the
+# first smoke uses a local lightweight Ollama sidecar only for embeddings.
+EMBEDDING_MODEL=nomic-embed-text
+EMBEDDING_BASE_URL=http://embedding-ollama:11434
+
+# Host-local smoke ports. Traefik/platform integration should route only the UI.
+MIROFISH_UI_PORT=13000
+MIROFISH_API_PORT=15001

--- a/deploy/rs2000/docker-compose.cloud-smoke.yml
+++ b/deploy/rs2000/docker-compose.cloud-smoke.yml
@@ -1,0 +1,69 @@
+name: mirofish-online
+
+services:
+  mirofish:
+    build:
+      context: ../..
+    container_name: mirofish-online
+    env_file:
+      - path: ../../.env
+        required: false
+    ports:
+      - "127.0.0.1:${MIROFISH_UI_PORT:-13000}:3000"
+      - "127.0.0.1:${MIROFISH_API_PORT:-15001}:5001"
+    restart: unless-stopped
+    volumes:
+      - ../../backend/uploads:/app/backend/uploads
+    depends_on:
+      neo4j:
+        condition: service_healthy
+      embedding-ollama:
+        condition: service_started
+    networks:
+      - mirofish-private
+
+  neo4j:
+    image: neo4j:5.18-community
+    container_name: mirofish-online-neo4j
+    environment:
+      - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:?set NEO4J_PASSWORD}
+      - NEO4J_PLUGINS=["apoc"]
+      - NEO4J_server_memory_heap_initial__size=512m
+      - NEO4J_server_memory_heap_max__size=1g
+      - NEO4J_server_memory_pagecache_size=512m
+    mem_limit: 2g
+    ports:
+      - "127.0.0.1:17474:7474"
+      - "127.0.0.1:17687:7687"
+    volumes:
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:7474 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - mirofish-private
+
+  embedding-ollama:
+    image: ollama/ollama:latest
+    container_name: mirofish-online-embedding-ollama
+    ports:
+      - "127.0.0.1:11435:11434"
+    volumes:
+      - embedding_ollama_data:/root/.ollama
+    restart: unless-stopped
+    networks:
+      - mirofish-private
+
+networks:
+  mirofish-private:
+    name: mirofish_online_private
+
+volumes:
+  neo4j_data:
+  neo4j_logs:
+  embedding_ollama_data:

--- a/docs/rs2000-smoke.md
+++ b/docs/rs2000-smoke.md
@@ -1,0 +1,82 @@
+# RS2000 Smoke Profile
+
+This fork is intended to become Piotr's private, Tailnet-only MiroFish variant:
+cloud LLM inference, local graph storage, and no paid Zep dependency.
+
+## Decisions
+
+- Repository name: `pdurlej/mirofish-online`.
+- Runtime target: RS2000.
+- Exposure: `mirofish.pdurlej.com` behind Tailnet/Traefik allowlist only.
+- LLM: Ollama Cloud / ProCloud through the OpenAI-compatible API.
+- First model: `qwen3.5:cloud`; `qwen3.5:397b-cloud` is a later quality/cost comparison.
+- Graph store: Neo4j Community for the first smoke, with memory limits.
+- Embeddings: local lightweight Ollama sidecar for `nomic-embed-text`, because the current code calls Ollama `/api/embed` directly.
+- Backups: no initial backup for uploads/graph state until product value is proven.
+
+## Non-goals
+
+- No public exposure of Neo4j Browser/Bolt, backend API, or UI.
+- No local large LLM on RS2000.
+- No Postgres graph-storage adapter until the smoke proves product value.
+- No platform canonical module until the standalone smoke is useful.
+
+## Local checkout
+
+```bash
+git clone https://github.com/pdurlej/mirofish-online.git /Users/pd/Developer/mirofish-online
+cd /Users/pd/Developer/mirofish-online
+```
+
+## RS2000 smoke env
+
+Render `.env` from Infisical or create a local throwaway file from:
+
+```bash
+cp deploy/rs2000/.env.example .env
+```
+
+Never commit `.env`.
+
+Required secret-backed values:
+
+- `LLM_API_KEY`
+- `OPENAI_API_KEY` with the same value as `LLM_API_KEY`
+- `NEO4J_PASSWORD`
+- `SECRET_KEY`
+
+## Start smoke stack
+
+```bash
+docker compose -f deploy/rs2000/docker-compose.cloud-smoke.yml up -d neo4j embedding-ollama
+docker exec mirofish-online-embedding-ollama ollama pull nomic-embed-text
+docker compose -f deploy/rs2000/docker-compose.cloud-smoke.yml up -d --build mirofish
+```
+
+The smoke compose binds host ports to `127.0.0.1` only:
+
+- UI: `127.0.0.1:13000`
+- backend API: `127.0.0.1:15001`
+- Neo4j Browser: `127.0.0.1:17474`
+- Neo4j Bolt: `127.0.0.1:17687`
+- embedding Ollama: `127.0.0.1:11435`
+
+## Health checks
+
+```bash
+curl -fsS http://127.0.0.1:15001/health
+curl -fsS http://127.0.0.1:13000/
+docker ps --filter name=mirofish-online --format 'table {{.Names}}\t{{.Status}}'
+```
+
+## Platform integration gate
+
+Only after a useful smoke result, add the canonical `platform` repo trace:
+
+- `modules/mirofish-online/module.yaml`
+- `modules/mirofish-online/runbook.md`
+- `compose/apps/compose.yaml` service slice or a documented external-compose module
+- `docs/infisical/key-map.md` entry for `/home-platform/apps/mirofish-online`
+- `state/reports/mirofish-online-smoke-YYYY-MM-DD.md`
+
+Keep the first module lifecycle as `experiment`, not `active`.


### PR DESCRIPTION
## Summary

Prepare this fork for Piotr's RS2000 smoke path:

- add a private cloud-LLM + Neo4j smoke compose profile
- add secret-free RS2000 env example
- document Tailnet-only exposure, Neo4j limits, and local embedding sidecar
- keep Postgres adapter and platform canonical module out of scope until product value is proven

## Validation

- docker compose --env-file deploy/rs2000/.env.example -f deploy/rs2000/docker-compose.cloud-smoke.yml config --quiet

## Non-goals

- no runtime start
- no secrets
- no platform repo changes
- no public exposure
- no Postgres graph adapter yet